### PR TITLE
ci: pin Linux jobs to Ubuntu 24.04

### DIFF
--- a/.github/workflows/nextjs.yaml
+++ b/.github/workflows/nextjs.yaml
@@ -10,7 +10,7 @@ jobs:
    execute:
       env:
          IMAGE: ghcr.io/davidilie/laundrey-web
-      runs-on: davidapps-linux-x64
+      runs-on: ubuntu-24.04
       steps:
          - name: Generate build ID
            id: prep


### PR DESCRIPTION
## Summary

- pin applicable Linux jobs to GitHub-hosted Ubuntu 24.04
- preserve existing workflow triggers, permissions, steps, and non-Linux runners

## Validation

- parsed each changed workflow as YAML
- ran actionlint on each changed workflow (excluding unrelated pre-existing deprecation/action-version diagnostics)
- ran git diff --check
- reviewed the final diff to confirm only runs-on values changed